### PR TITLE
bugfix/ajax

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -266,7 +266,13 @@
       }
     }
 
-    var xhrCopy = $.extend({}, xhr)
+    var xhrCopy = new window.XMLHttpRequest();
+
+    Object.keys(xhr).forEach(function(key) {
+      if (!/response|blob|withcredentials/gi.test(key)) {
+        xhrCopy[key] = xhr[key];
+      }
+    });
 
     if (ajaxBeforeSend(xhrCopy, settings) === false) {
       xhr.abort()


### PR DESCRIPTION
fix a dom error on certain webkit versions when accessing a readonly prop of the xhr object
